### PR TITLE
pxacid.pl, pxpjcid.pl ($ser_kb): added extra series

### DIFF
--- a/pxacid.pl
+++ b/pxacid.pl
@@ -1338,17 +1338,21 @@ sub use_berry { $use_berry = $_[0]; }
 
 # NFSS シリーズ名 → Berry 規則識別子
 our $ser_kb = {
-  ul => 'a', # UltraLight
-  el => 'j', # ExtraLight
-  l => 'l',  # Light
-  m => 'r',  # Regular
-  mb => 'm', # Medium
-  db => 'd', # DemiBold
-  sb => 's', # SemiBold
-  b => 'b',  # Bold
-  bx => 'b', # Bold
-  eb => 'x', # Extra
-  ub => 'u'  # Ultra
+  ul => 'a',  # UltraLight
+  el => 'j',  # ExtraLight
+  l => 'l',   # Light
+  dl => 'dl', # DemiLight (non-standard?)
+  m => 'r',   # Regular
+  mb => 'm',  # Medium
+  db => 'd',  # DemiBold
+  sb => 's',  # SemiBold
+  b => 'b',   # Bold
+  bx => 'b',  # Bold
+  eb => 'x',  # ExtraBold
+  h => 'h',   # Heavy (non-standard?)
+  eh => 'xh', # ExtraHeavy (non-standard?)
+  ub => 'u',  # Ultra
+  uh => 'uh'  # UltraHeavy (non-standard?)
 };
 # NFSS シェープ名 → Berry 規則識別子
 our $shp_kb = {

--- a/pxpjcid.pl
+++ b/pxpjcid.pl
@@ -389,17 +389,21 @@ sub use_berry { } # no-pp
 
 # NFSS series -> Berry
 our $ser_kb = {
-  ul => 'a', # UltraLight
-  el => 'j', # ExtraLight
-  l => 'l',  # Light
-  m => 'r',  # Regular
-  mb => 'm', # Medium
-  db => 'd', # DemiBold
-  sb => 's', # SemiBold
-  b => 'b',  # Bold
-  bx => 'b', # Bold
-  eb => 'x', # Extra
-  ub => 'u'  # Ultra
+  ul => 'a',  # UltraLight
+  el => 'j',  # ExtraLight
+  l => 'l',   # Light
+  dl => 'dl', # DemiLight (non-standard?)
+  m => 'r',   # Regular
+  mb => 'm',  # Medium
+  db => 'd',  # DemiBold
+  sb => 's',  # SemiBold
+  b => 'b',   # Bold
+  bx => 'b',  # Bold
+  eb => 'x',  # ExtraBold
+  h => 'h',   # Heavy (non-standard?)
+  eh => 'xh', # ExtraHeavy (non-standard?)
+  ub => 'u',  # Ultra
+  uh => 'uh'  # UltraHeavy (non-standard?)
 };
 # counterpart
 our $enc_tate = {


### PR DESCRIPTION
いくつか `$ser_kb` を追加しました。

従来より、モリサワ系フォントなどにあった和文書体のウェイトや最近、源ノに登場した DemiLight などに対応すべく、non-standardなBerry規則識別子もあります。
